### PR TITLE
Define caml_incremental_roots_count in byterun

### DIFF
--- a/byterun/caml/roots.h
+++ b/byterun/caml/roots.h
@@ -23,7 +23,7 @@ void caml_oldify_local_roots (void);
 void caml_darken_all_roots_start (void);
 intnat caml_darken_all_roots_slice (intnat);
 void caml_do_roots (scanning_action, int);
-uintnat caml_incremental_roots_count;
+extern uintnat caml_incremental_roots_count;
 #ifndef NATIVE_CODE
 CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
                                      struct caml__roots_block *);

--- a/byterun/roots.c
+++ b/byterun/roots.c
@@ -65,7 +65,7 @@ void caml_darken_all_roots_start (void)
   caml_do_roots (caml_darken, 1);
 }
 
-uintnat caml_number_of_incremental_roots = 1;
+uintnat caml_incremental_roots_count = 1;
 
 intnat caml_darken_all_roots_slice (intnat work)
 {


### PR DESCRIPTION
It seems that caml_incremental_roots_count was at some point renamed from caml_number_of_incremental_roots, but only asmrun/roots.c was updated. This would have been caught if the declaration in the header was external, so I changed that as well.
