### PR TITLE
Fix caml_obj_truncate

### DIFF
--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -217,7 +217,8 @@ CAMLextern value caml_hash_variant(char const * tag);
 #define Byte_u(x, i) (((unsigned char *) (x)) [i]) /* Also an l-value. */
 
 /* Abstract things.  Their contents is not traced by the GC; therefore they
-   must not contain any [value].
+   must not contain any [value]. Must have odd number so that headers with
+   this tag cannot be mistaken for pointers (see caml_obj_truncate).
 */
 #define Abstract_tag 251
 

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -124,9 +124,13 @@ CAMLprim value caml_obj_dup(value arg)
    to 0 or greater than the current size.
 
    algorithm:
-   Change the length field of the header.  Make up a white object
+   Change the length field of the header.  Make up a black object
    with the leftover part of the object: this is needed in the major
-   heap and harmless in the minor heap.
+   heap and harmless in the minor heap. The object cannot be white
+   because there may still be references to it in the ref table. By
+   using a black object we ensure that the ref table will be emptied
+   before the block is reallocated (since there must be a minor
+   collection within each major cycle).
 */
 CAMLprim value caml_obj_truncate (value v, value newsize)
 {
@@ -158,7 +162,7 @@ CAMLprim value caml_obj_truncate (value v, value newsize)
      look like a pointer because there may be some references to it in
      ref_table. */
   Field (v, new_wosize) =
-    Make_header (Wosize_whsize (wosize-new_wosize), 1, Caml_white);
+    Make_header (Wosize_whsize (wosize-new_wosize), Abstract_tag, Caml_black);
   Hd_val (v) = Make_header (new_wosize, tag, color);
   return Val_unit;
 }


### PR DESCRIPTION
Since sweeping can now occur before the ref table is emptied,
overflow objects created by Obj.truncate must be marked Caml_black
to avoid them being reallocated whilst still in the ref table.
Using Caml_black means that Abstract_tag should be used instead
of 1 in case the contents of the block are not safe to scan.
